### PR TITLE
Scope vendor down to current_user

### DIFF
--- a/app/controllers/vendor_admin/vendors_controller.rb
+++ b/app/controllers/vendor_admin/vendors_controller.rb
@@ -1,10 +1,10 @@
 class VendorAdmin::VendorsController < ApplicationController
   def show
-    @vendor = Vendor.find(params[:id])
+    @vendor = current_user.vendors.find(params[:id])
   end
 
   def update
-    @vendor = Vendor.find(params[:id])
+    @vendor = current_user.vendors.find(params[:id])
     if @vendor.update(vendor_params)
       if params[:commit] == "Take Store Offline"
         flash[:success] = "Store Successfully Taken Offline"

--- a/spec/features/vendor_can_edit_their_store_spec.rb
+++ b/spec/features/vendor_can_edit_their_store_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.feature "Vendor can edit their store" do
   scenario "vendor edits their store" do
-    category = Category.create(name: "new category")
     user = User.create(username: "test", password: "pass", password_confirmation: "pass", email: "who@gmail.com" )
     role = Role.create(name: "vendor_admin")
     vendor = Vendor.create(name: "Vendor1")
@@ -25,5 +24,22 @@ RSpec.feature "Vendor can edit their store" do
     expect(current_path).to eq(dashboard_path(user.id))
     expect(page).to have_content("Vendor Information Updated")
     expect(page).to have_content("New Vendor Name")
+  end
+
+  scenario 'vendor cannot edit another vendor store' do
+    user     = User.create(username: "test", password: "pass", password_confirmation: "pass", email: "who@gmail.com" )
+    role     = Role.create(name: "vendor_admin")
+    vendor1  = Vendor.create(name: "Vendor1")
+    vendor2  = Vendor.create(name: "Vendor2")
+    UserRole.create(user_id: user.id, vendor_id: vendor1.id, role_id: role.id)
+
+    visit login_path
+    fill_in "Username", with: "test"
+    fill_in "Password", with: "pass"
+    click_button "Sign In"
+
+    within(".dashboard") do
+      expect(page).not_to have_content("Vendor2")
+    end
   end
 end


### PR DESCRIPTION
Scoped the vendor admin show and update methods down to current user preventing malicious vendor admins from editing other vendors' sites. Tests passing. Recommend merge to master.